### PR TITLE
simplify: derive connection_id from JWT sub claim instead of URL path

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A lightweight, self-hosted tunneling proxy built with FastAPI. Expose local serv
 ## How It Works
 
 1. The **server** accepts HTTP requests at `/{connection_id}/{path}` and holds them.
-2. A **client** connects via WebSocket to `/{connection_id}?token=<jwt>`, receives forwarded requests, proxies them to your local service, and sends responses back.
+2. A **client** connects via WebSocket to `/?token=<jwt>`, receives forwarded requests, proxies them to your local service, and sends responses back. The connection ID is extracted from the JWT `sub` claim.
 3. The server returns the response to the original caller.
 
 Request/response bodies are base64-encoded for binary-safe transport over the JSON WebSocket channel.
@@ -30,7 +30,7 @@ python -m pipegate.auth
 python -m pipegate.server
 
 # Start the client (in another terminal)
-python -m pipegate.client http://localhost:3000 "ws://yourserver:8000/{connection_id}?token={jwt}"
+python -m pipegate.client http://localhost:3000 "ws://yourserver:8000/?token={jwt}"
 ```
 
 ## Configuration
@@ -51,7 +51,9 @@ Environment variables (via pydantic-settings):
 |---|---|
 | `GET /healthz` | Health check — `{"status": "ok"}` |
 | `* /{connection_id}/{path}` | Tunnel HTTP endpoint (all methods) |
-| `WS /{connection_id}?token=<jwt>` | WebSocket tunnel (JWT required) |
+| `WS /?token=<jwt>` | WebSocket tunnel (JWT required, connection ID from `sub` claim) |
+
+The connection ID is embedded inside the JWT as the `sub` (subject) claim. The **JWT is the only credential the tunnel client needs** — no separate connection ID argument. External HTTP callers still use the connection ID in the URL path (`/{connection_id}/{path}`), and the server extracts it from the JWT when the tunnel client connects to route traffic to the correct WebSocket tunnel.
 
 ## Development
 

--- a/pipegate/auth.py
+++ b/pipegate/auth.py
@@ -8,19 +8,14 @@ import jwt
 from .schemas import JWTPayload, Settings
 
 
-def verify_token(token: str, connection_id: str, settings: Settings) -> JWTPayload:
-    """Decode and verify a JWT token matches the given connection ID."""
+def verify_token(token: str, settings: Settings) -> JWTPayload:
+    """Decode and verify a JWT token, returning the payload (including connection ID in ``sub``)."""
     decoded = jwt.decode(
         token,
         settings.jwt_secret.get_secret_value(),
         algorithms=settings.jwt_algorithms,
     )
-    payload = JWTPayload.model_validate(decoded)
-
-    if payload.sub != connection_id:
-        raise PermissionError("Token UUID does not match path UUID")
-
-    return payload
+    return JWTPayload.model_validate(decoded)
 
 
 def make_jwt_bearer() -> None:

--- a/pipegate/auth.py
+++ b/pipegate/auth.py
@@ -9,7 +9,7 @@ from .schemas import JWTPayload, Settings
 
 
 def verify_token(token: str, settings: Settings) -> JWTPayload:
-    """Decode and verify a JWT token, returning the payload (including connection ID in ``sub``)."""
+    """Decode and verify a JWT, returning the payload (connection ID in ``sub``)."""
     decoded = jwt.decode(
         token,
         settings.jwt_secret.get_secret_value(),

--- a/pipegate/server.py
+++ b/pipegate/server.py
@@ -138,9 +138,8 @@ def create_app() -> FastAPI:
             status_code=response.status_code,
         )
 
-    @app.websocket("/{connection_id}")
+    @app.websocket("/")
     async def handle_websocket(
-        connection_id: str,
         websocket: WebSocket,
     ) -> None:
         settings: Settings = websocket.app.extra["settings"]
@@ -149,11 +148,13 @@ def create_app() -> FastAPI:
             await websocket.close(code=1008, reason="Missing token")
             return
         try:
-            verify_token(token, connection_id, settings)
+            payload = verify_token(token, settings)
         except Exception as exc:
-            logger.warning("WebSocket auth failed for %s: %s", connection_id, exc)
+            logger.warning("WebSocket auth failed: %s", exc)
             await websocket.close(code=1008, reason="Invalid token")
             return
+
+        connection_id = payload.sub
 
         await websocket.accept()
         logger.info("WebSocket connected: %s", connection_id)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -14,7 +14,7 @@ from .conftest import make_token
 class TestVerifyToken:
     def test_valid_token(self, connection_id: str, settings: Settings) -> None:
         token = make_token(connection_id)
-        result = verify_token(token, connection_id, settings)
+        result = verify_token(token, settings)
 
         assert isinstance(result, JWTPayload)
         assert result.sub == connection_id
@@ -23,24 +23,18 @@ class TestVerifyToken:
         token = make_token(connection_id, expires_in=timedelta(seconds=-1))
 
         with pytest.raises(jwt.ExpiredSignatureError):
-            verify_token(token, connection_id, settings)
-
-    def test_wrong_connection_id(self, connection_id: str, settings: Settings) -> None:
-        token = make_token(connection_id)
-
-        with pytest.raises(PermissionError, match="does not match"):
-            verify_token(token, "wrong-id", settings)
+            verify_token(token, settings)
 
     def test_wrong_secret(self, connection_id: str, settings: Settings) -> None:
         token = make_token(connection_id, secret="wrong-secret-that-is-long-enough!!")
 
         with pytest.raises(jwt.InvalidSignatureError):
-            verify_token(token, connection_id, settings)
+            verify_token(token, settings)
 
     def test_malformed_token(self, settings: Settings) -> None:
         with pytest.raises(jwt.DecodeError):
-            verify_token("not.a.jwt", "any-id", settings)
+            verify_token("not.a.jwt", settings)
 
     def test_empty_token(self, settings: Settings) -> None:
         with pytest.raises(jwt.DecodeError):
-            verify_token("", "any-id", settings)
+            verify_token("", settings)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -58,7 +58,7 @@ async def _ws_roundtrip(
                 "type": "websocket",
                 "asgi": {"version": "3.0"},
                 "http_version": "1.1",
-                "path": f"/{connection_id}",
+                "path": "/",
                 "query_string": f"token={token}".encode(),
                 "headers": [],
             }
@@ -106,7 +106,6 @@ async def _ws_roundtrip(
 
 async def _connect_ws(
     app: FastAPI,
-    connection_id: str,
     *,
     token: str | None = None,
 ) -> str:
@@ -116,7 +115,7 @@ async def _connect_ws(
         "type": "websocket",
         "asgi": {"version": "3.0"},
         "http_version": "1.1",
-        "path": f"/{connection_id}",
+        "path": "/",
         "query_string": query.encode(),
         "headers": [],
     }
@@ -223,7 +222,7 @@ class TestTunnelRoundTrip:
                     "type": "websocket",
                     "asgi": {"version": "3.0"},
                     "http_version": "1.1",
-                    "path": f"/{connection_id}",
+                    "path": "/",
                     "query_string": f"token={token}".encode(),
                     "headers": [],
                 }
@@ -280,7 +279,7 @@ class TestTunnelRoundTrip:
                     "type": "websocket",
                     "asgi": {"version": "3.0"},
                     "http_version": "1.1",
-                    "path": f"/{connection_id}",
+                    "path": "/",
                     "query_string": f"token={token}".encode(),
                     "headers": [],
                 }
@@ -343,7 +342,7 @@ class TestDisconnect:
                     "type": "websocket",
                     "asgi": {"version": "3.0"},
                     "http_version": "1.1",
-                    "path": f"/{connection_id}",
+                    "path": "/",
                     "query_string": f"token={token}".encode(),
                     "headers": [],
                 }
@@ -384,7 +383,7 @@ class TestDisconnect:
             "type": "websocket",
             "asgi": {"version": "3.0"},
             "http_version": "1.1",
-            "path": f"/{connection_id}",
+            "path": "/",
             "query_string": f"token={token}".encode(),
             "headers": [],
         }
@@ -422,7 +421,7 @@ class TestDisconnect:
                     "type": "websocket",
                     "asgi": {"version": "3.0"},
                     "http_version": "1.1",
-                    "path": f"/{connection_id}",
+                    "path": "/",
                     "query_string": f"token={token}".encode(),
                     "headers": [],
                 }
@@ -462,31 +461,18 @@ class TestDisconnect:
 
 
 class TestWebSocketAuth:
-    async def test_rejected_without_token(self, connection_id: str) -> None:
-        assert await _connect_ws(_make_app(), connection_id) == "websocket.close"
-
-    async def test_rejected_with_wrong_token(self, connection_id: str) -> None:
-        wrong = make_token(uuid.uuid4().hex)
-        assert (
-            await _connect_ws(_make_app(), connection_id, token=wrong)
-            == "websocket.close"
-        )
+    async def test_rejected_without_token(self) -> None:
+        assert await _connect_ws(_make_app()) == "websocket.close"
 
     async def test_rejected_with_expired_token(self, connection_id: str) -> None:
         from datetime import timedelta
 
         expired = make_token(connection_id, expires_in=timedelta(seconds=-1))
-        assert (
-            await _connect_ws(_make_app(), connection_id, token=expired)
-            == "websocket.close"
-        )
+        assert await _connect_ws(_make_app(), token=expired) == "websocket.close"
 
     async def test_accepted_with_valid_token(self, connection_id: str) -> None:
         valid = make_token(connection_id)
-        assert (
-            await _connect_ws(_make_app(), connection_id, token=valid)
-            == "websocket.accept"
-        )
+        assert await _connect_ws(_make_app(), token=valid) == "websocket.accept"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,7 +4,6 @@ import asyncio
 import base64
 import contextlib
 import json
-import uuid
 from typing import cast
 
 import orjson


### PR DESCRIPTION
The tunnel client no longer needs to supply the connection_id in the WebSocket URL — it is extracted from the JWT `sub` claim on the server side. This reduces the client invocation from:

  python -m pipegate.client <target> "ws://server:8000/{id}?token={jwt}"

to:

  python -m pipegate.client <target> "ws://server:8000/?token={jwt}"

Changes:
- WebSocket route changed from /{connection_id} to /
- verify_token() no longer takes or checks a connection_id parameter
- Removed test_ws_rejected_with_wrong_token (no URL path to mismatch)
- README updated with JWT/connection-id relationship explanation