### PR TITLE
fix: race condition in queue creation and deprecated asyncio API

### DIFF
--- a/pipegate/client.py
+++ b/pipegate/client.py
@@ -46,7 +46,7 @@ async def handle_request(
         typer.echo(f"Error processing request {request.correlation_id}: {e}", err=True)
         payload = BufferGateResponse(
             correlation_id=request.correlation_id,
-            headers="",
+            headers="{}",
             body="",
             status_code=504,
         )

--- a/pipegate/server.py
+++ b/pipegate/server.py
@@ -75,15 +75,16 @@ def create_app() -> FastAPI:
                 detail=f"Request body exceeds limit of {settings.max_body_bytes} bytes",
             )
 
-        loop = asyncio.get_event_loop()
-        future: asyncio.Future[BufferGateResponse] = loop.create_future()
+        running_loop = asyncio.get_running_loop()
+        future: asyncio.Future[BufferGateResponse] = running_loop.create_future()
         futures[correlation_id] = future
 
-        if connection_id not in buffers:
-            buffers[connection_id] = asyncio.Queue(maxsize=settings.max_queue_depth)
+        queue = buffers.setdefault(
+            connection_id, asyncio.Queue(maxsize=settings.max_queue_depth)
+        )
 
         try:
-            buffers[connection_id].put_nowait(
+            queue.put_nowait(
                 BufferGateRequest(
                     correlation_id=correlation_id,
                     method=cast(Methods, request.method),
@@ -147,8 +148,9 @@ def create_app() -> FastAPI:
         await websocket.accept()
         logger.info("WebSocket connected: %s", connection_id)
 
-        if connection_id not in buffers:
-            buffers[connection_id] = asyncio.Queue(maxsize=settings.max_queue_depth)
+        queue = buffers.setdefault(
+            connection_id, asyncio.Queue(maxsize=settings.max_queue_depth)
+        )
 
         async def receive() -> None:
             try:
@@ -170,7 +172,7 @@ def create_app() -> FastAPI:
 
         async def send() -> None:
             while True:
-                request = await buffers[connection_id].get()
+                request = await queue.get()
                 try:
                     await websocket.send_text(request.model_dump_json())
                 except WebSocketDisconnect:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.ruff]
 target-version = "py312"


### PR DESCRIPTION
- Use setdefault() for atomic queue creation, fixing race between HTTP and WebSocket handlers that could orphan requests
- Replace deprecated asyncio.get_event_loop() with get_running_loop()
- Fix empty headers string in error response ("{}" instead of "")
- Add asyncio_default_fixture_loop_scope to pytest config